### PR TITLE
Use grep ignoring alias

### DIFF
--- a/fuzzy-match.zsh
+++ b/fuzzy-match.zsh
@@ -23,7 +23,7 @@ done
 local default_keys='^T' map
 
 for map in emacs viins vicmd; do
-	bindkey -M $map | grep -q 'fuzzy-match' || bindkey -M $map $default_keys fuzzy-match
+	bindkey -M $map | "grep" -q 'fuzzy-match' || bindkey -M $map $default_keys fuzzy-match
 done
 
 }


### PR DESCRIPTION
Many people out there use an aliased grep. Eg aliased to [ag](https://github.com/ggreer/the_silver_searcher) or [ack](https://github.com/petdance/ack2). The aliased grep may not have a -q option, so to improve compatibility i suggest that the unaliased grep is used instead.
